### PR TITLE
RSLC-10- Admin targets

### DIFF
--- a/app/admin/targets.rb
+++ b/app/admin/targets.rb
@@ -1,0 +1,26 @@
+ActiveAdmin.register Target do
+  permit_params :title, :lat, :lng, :radius, :topic_id
+  index do
+    selectable_column
+    id_column
+    column :title
+    column :radius, min: 0
+    column :lat
+    column :lng
+    column :topic
+    column :user
+    actions
+  end
+  filter :title
+  filter :radius
+  filter :lat
+  filter :lng
+  filter :topic
+  filter :user
+
+  controller do
+    def scoped_collection
+      super.includes(:topic, :user)
+    end
+  end
+end

--- a/app/admin/targets.rb
+++ b/app/admin/targets.rb
@@ -12,9 +12,6 @@ ActiveAdmin.register Target do
     actions
   end
   filter :title
-  filter :radius
-  filter :lat
-  filter :lng
   filter :topic
   filter :user
 

--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -19,7 +19,7 @@
 #
 class Target < ApplicationRecord
   validates :title, presence: true
-  validates :radius, presence: true, numericality: { greater_than: 0 }
+  validates :radius, presence: true, numericality: { greater_than_or_equal_to: 0 }
   validates :lat, :lng, presence: true, numericality: true
 
   scope :exclude_current_user, ->(current_user_id) { where.not(user_id: current_user_id) }

--- a/spec/admin/target_spec.rb
+++ b/spec/admin/target_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Admin Targets', type: :request do
     sign_in admin_user
   end
 
-  describe 'Show all targets' do
+  describe 'GET /admin/targets' do
     it 'displays all targets for the admin user' do
       target1 = FactoryBot.create(:target, title: 'Target 1')
       target2 = FactoryBot.create(:target, title: 'Target 2')

--- a/spec/admin/target_spec.rb
+++ b/spec/admin/target_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Admin Targets', type: :request do
 
       get '/admin/targets'
 
-      expect(response).to have_http_status(200)
+      expect(response).to be_successful
 
       expect(response.body).to include(target1.title)
       expect(response.body).to include(target2.title)

--- a/spec/admin/target_spec.rb
+++ b/spec/admin/target_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin Targets', type: :request do
+  let(:admin_user) { FactoryBot.create(:admin_user) }
+
+  before do
+    sign_in admin_user
+  end
+
+  describe 'Show all targets' do
+    it 'displays all targets for the admin user' do
+      target1 = FactoryBot.create(:target, title: 'Target 1')
+      target2 = FactoryBot.create(:target, title: 'Target 2')
+
+      get '/admin/targets'
+
+      expect(response).to have_http_status(200)
+
+      expect(response.body).to include(target1.title)
+      expect(response.body).to include(target2.title)
+    end
+  end
+end

--- a/spec/models/target_spec.rb
+++ b/spec/models/target_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Target, type: :model do
     it { is_expected.to validate_presence_of(:radius) }
     it { is_expected.to validate_presence_of(:lat) }
     it { is_expected.to validate_presence_of(:lng) }
-    it { is_expected.to validate_numericality_of(:radius).is_greater_than(0) }
+    it { is_expected.to validate_numericality_of(:radius).is_greater_than_or_equal_to(0) }
     it { is_expected.to validate_numericality_of(:lat) }
     it { is_expected.to validate_numericality_of(:lng) }
     it { is_expected.to belong_to(:user) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -24,6 +24,7 @@ WebMock.disable_net_connect!(allow_localhost: true)
 RSpec.configure do |config|
   config.render_views = true
   config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::IntegrationHelpers, type: :request
   config.include ActiveJob::TestHelper
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
#### Board:
* [RSLC-10](https://trello.com/c/cP7DeQpg/9-rslc-10-as-an-admin-i-should-be-able-to-see-all-the-targets-in-the-system)
---
#### Description:
As an admin I should be able to see all the targets in the system.
The [Rails API Base project](https://github.com/rslearningcamp/rails_api_base) comes with the ActiveAdmin gem, an administration framework with a visual interface. We recommend reading their guidelines: [Active Admin | The administration framework for Ruby on Rails](https://activeadmin.info/)

![image](https://github.com/RCarmona53/rootstrap_target_app/assets/90734627/c30ec7e7-c8ae-4e2c-a723-c7ebb7439ca6)
